### PR TITLE
markedjs vulnerability, 0.3.7 -> 0.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1521,7 +1521,7 @@
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",


### PR DESCRIPTION
Known vulnerability found
CVE-2017-17461
Moderate severity
A Regular expression Denial of Service (ReDoS) vulnerability in the file marked.js of the marked npm package (tested ...

package-lock.json update suggested:
marked ~> 0.3.9
Always verify the validity and compatibility of suggestions with your codebase.